### PR TITLE
Use standard objects rather than arrays for oauth storage

### DIFF
--- a/lib/scribe.js
+++ b/lib/scribe.js
@@ -1,6 +1,7 @@
 (function() {
-  var BaseStringExtractorImpl, DefaultApi, HMACSha1SignatureService, HeaderExtractorImpl, JsonTokenExtractorImpl, OAuth10aServiceImpl, OAuth20ServiceImpl, OAuthConfig, OAuthConstants, OAuthRequest, OAuthServiceImpl, PlaintextSignatureService, Request, SignatureType, Timer, TimestampServiceImpl, TokenExtractor20Impl, TokenExtractorImpl, Verb, crypto, decode_data, encode_data, extract_token, http, https, object_merge, params_to_query, root, sort_by_keys, sort_obj, url;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var BaseStringExtractorImpl, DefaultApi, HMACSha1SignatureService, HeaderExtractorImpl, JsonTokenExtractorImpl, OAuth10aServiceImpl, OAuth20ServiceImpl, OAuthConfig, OAuthConstants, OAuthRequest, OAuthServiceImpl, PlaintextSignatureService, Request, SignatureType, Timer, TimestampServiceImpl, TokenExtractor20Impl, TokenExtractorImpl, Verb, crypto, decode_data, encode_data, extract_token, http, https, object_merge, params_to_query, root, sort_by_keys, sort_obj, url,
+    __hasProp = Object.prototype.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
@@ -491,9 +492,9 @@
 
   })();
 
-  OAuthRequest = (function() {
+  OAuthRequest = (function(_super) {
 
-    __extends(OAuthRequest, Request);
+    __extends(OAuthRequest, _super);
 
     function OAuthRequest(verb, url) {
       OAuthRequest.__super__.constructor.call(this, verb, url);
@@ -506,7 +507,7 @@
 
     return OAuthRequest;
 
-  })();
+  })(Request);
 
   OAuthConfig = (function() {
 
@@ -613,9 +614,9 @@
 
   })();
 
-  OAuth10aServiceImpl = (function() {
+  OAuth10aServiceImpl = (function(_super) {
 
-    __extends(OAuth10aServiceImpl, OAuthServiceImpl);
+    __extends(OAuth10aServiceImpl, _super);
 
     function OAuth10aServiceImpl(api, config) {
       this.api = api;
@@ -695,7 +696,7 @@
 
     return OAuth10aServiceImpl;
 
-  })();
+  })(OAuthServiceImpl);
 
   DefaultApi = (function() {
 
@@ -736,9 +737,9 @@
 
   })();
 
-  root.DefaultApi10a = (function() {
+  root.DefaultApi10a = (function(_super) {
 
-    __extends(DefaultApi10a, DefaultApi);
+    __extends(DefaultApi10a, _super);
 
     function DefaultApi10a() {
       DefaultApi10a.__super__.constructor.apply(this, arguments);
@@ -774,11 +775,11 @@
 
     return DefaultApi10a;
 
-  })();
+  })(DefaultApi);
 
-  OAuth20ServiceImpl = (function() {
+  OAuth20ServiceImpl = (function(_super) {
 
-    __extends(OAuth20ServiceImpl, OAuthServiceImpl);
+    __extends(OAuth20ServiceImpl, _super);
 
     function OAuth20ServiceImpl(api, config) {
       this.api = api;
@@ -856,11 +857,11 @@
 
     return OAuth20ServiceImpl;
 
-  })();
+  })(OAuthServiceImpl);
 
-  root.DefaultApi20 = (function() {
+  root.DefaultApi20 = (function(_super) {
 
-    __extends(DefaultApi20, DefaultApi);
+    __extends(DefaultApi20, _super);
 
     function DefaultApi20() {
       DefaultApi20.__super__.constructor.apply(this, arguments);
@@ -888,7 +889,7 @@
 
     return DefaultApi20;
 
-  })();
+  })(DefaultApi);
 
   root.ServiceBuilder = (function() {
 

--- a/lib/widgets/FacebookApi.js
+++ b/lib/widgets/FacebookApi.js
@@ -1,14 +1,15 @@
 (function() {
-  var api, root;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var api, root,
+    __hasProp = Object.prototype.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
   api = require('../scribe').DefaultApi20;
 
-  root.FacebookApi = (function() {
+  root.FacebookApi = (function(_super) {
 
-    __extends(FacebookApi, api);
+    __extends(FacebookApi, _super);
 
     function FacebookApi() {
       this.AUTHORIZE_URL = "https://www.facebook.com/dialog/oauth?response_type=token";
@@ -41,6 +42,6 @@
 
     return FacebookApi;
 
-  })();
+  })(api);
 
 }).call(this);

--- a/lib/widgets/GoogleApi.js
+++ b/lib/widgets/GoogleApi.js
@@ -1,14 +1,15 @@
 (function() {
-  var api, root;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var api, root,
+    __hasProp = Object.prototype.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
   api = require('../scribe').DefaultApi10a;
 
-  root.GoogleApi = (function() {
+  root.GoogleApi = (function(_super) {
 
-    __extends(GoogleApi, api);
+    __extends(GoogleApi, _super);
 
     function GoogleApi() {
       this.REQUEST_TOKEN_URL = "https://www.google.com/accounts/OAuthGetRequestToken";
@@ -57,6 +58,6 @@
 
     return GoogleApi;
 
-  })();
+  })(api);
 
 }).call(this);

--- a/lib/widgets/GoogleApi2.js
+++ b/lib/widgets/GoogleApi2.js
@@ -1,14 +1,15 @@
 (function() {
-  var api, root;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var api, root,
+    __hasProp = Object.prototype.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
   api = require('../scribe').DefaultApi20;
 
-  root.GoogleApi2 = (function() {
+  root.GoogleApi2 = (function(_super) {
 
-    __extends(GoogleApi2, api);
+    __extends(GoogleApi2, _super);
 
     function GoogleApi2() {
       this.AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/auth?response_type=code&";
@@ -52,6 +53,6 @@
 
     return GoogleApi2;
 
-  })();
+  })(api);
 
 }).call(this);

--- a/lib/widgets/LinkedInApi.js
+++ b/lib/widgets/LinkedInApi.js
@@ -1,14 +1,15 @@
 (function() {
-  var api, root;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var api, root,
+    __hasProp = Object.prototype.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
   api = require('../scribe').DefaultApi10a;
 
-  root.LinkedInApi = (function() {
+  root.LinkedInApi = (function(_super) {
 
-    __extends(LinkedInApi, api);
+    __extends(LinkedInApi, _super);
 
     function LinkedInApi() {
       this.REQUEST_TOKEN_URL = "https://api.linkedin.com/uas/oauth/requestToken";
@@ -42,6 +43,6 @@
 
     return LinkedInApi;
 
-  })();
+  })(api);
 
 }).call(this);

--- a/lib/widgets/OAuth.js
+++ b/lib/widgets/OAuth.js
@@ -77,9 +77,8 @@
 
     OAuth.prototype._init_storage = function() {
       if (!this.storage.oauth) {
-        this.storage.oauth = {
-          this.api: {}
-        };
+        this.storage.oauth = {};
+        this.storage.oauth[this.api] = {};
       } else if (!this.storage.oauth[this.api]) {
         this.storage.oauth[this.api] = {};
       }

--- a/lib/widgets/OAuth.js
+++ b/lib/widgets/OAuth.js
@@ -77,10 +77,11 @@
 
     OAuth.prototype._init_storage = function() {
       if (!this.storage.oauth) {
-        this.storage.oauth = [];
-        this.storage.oauth[this.api] = [];
+        this.storage.oauth = {
+          this.api: {}
+        };
       } else if (!this.storage.oauth[this.api]) {
-        this.storage.oauth[this.api] = [];
+        this.storage.oauth[this.api] = {};
       }
       return this.storage.oauth[this.api];
     };

--- a/lib/widgets/TwitterApi.js
+++ b/lib/widgets/TwitterApi.js
@@ -1,14 +1,15 @@
 (function() {
-  var api, root;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var api, root,
+    __hasProp = Object.prototype.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
   api = require('../scribe').DefaultApi10a;
 
-  root.TwitterApi = (function() {
+  root.TwitterApi = (function(_super) {
 
-    __extends(TwitterApi, api);
+    __extends(TwitterApi, _super);
 
     function TwitterApi() {
       this.REQUEST_TOKEN_URL = "http://api.twitter.com/oauth/request_token";
@@ -42,6 +43,6 @@
 
     return TwitterApi;
 
-  })();
+  })(api);
 
 }).call(this);

--- a/src/widgets/OAuth.coffee
+++ b/src/widgets/OAuth.coffee
@@ -65,7 +65,8 @@ class root.OAuth
   # private method
   _init_storage: () ->
     if not @storage.oauth
-      @storage.oauth = {@api: {}}
+      @storage.oauth = {}
+      @storage.oauth[@api] = {}
     else if not @storage.oauth[@api]
       @storage.oauth[@api] = {}
     return @storage.oauth[@api]

--- a/src/widgets/OAuth.coffee
+++ b/src/widgets/OAuth.coffee
@@ -65,10 +65,9 @@ class root.OAuth
   # private method
   _init_storage: () ->
     if not @storage.oauth
-      @storage.oauth = []
-      @storage.oauth[@api] = []
+      @storage.oauth = {@api: {}}
     else if not @storage.oauth[@api]
-      @storage.oauth[@api] = []
+      @storage.oauth[@api] = {}
     return @storage.oauth[@api]
 
   get_authorization_url: (callback) ->


### PR DESCRIPTION
This corrects a bug I encountered with Hubot being unable to persist the oauth details to disk.